### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/quantinuum-dev/qulacs-bridge/releases/tag/v0.1.0) - 2025-04-11
+
+### Added
+
+- Add PauliRotation support
+- Add more state functions
+- more gates and such
+
+### Other
+
+- Fix arguments
+- Specify release-plz arguments
+- Try updating packages
+- Add git client
+- Install devenv
+- Correct syntax
+- Try and use devenv
+- Try getting ci working
+- Correct shell syntax
+- Specify the shell
+- Reduce footprint of dev shell
+- Add nix dependencies
+- Create ci.yml
+- initial commit


### PR DESCRIPTION



## 🤖 New release

* `qulacs-bridge`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/quantinuum-dev/qulacs-bridge/releases/tag/v0.1.0) - 2025-04-11

### Added

- Add PauliRotation support
- Add more state functions
- more gates and such

### Other

- Fix arguments
- Specify release-plz arguments
- Try updating packages
- Add git client
- Install devenv
- Correct syntax
- Try and use devenv
- Try getting ci working
- Correct shell syntax
- Specify the shell
- Reduce footprint of dev shell
- Add nix dependencies
- Create ci.yml
- initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).