### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/quantinuum-dev/qulacs-bridge/compare/v0.1.0...v0.1.1) - 2025-04-11
+
+### Other
+
+- Pass env var
+- Improve pauli conversion
+
 ## [0.1.0](https://github.com/quantinuum-dev/qulacs-bridge/releases/tag/v0.1.0) - 2025-04-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "qulacs-bridge"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qulacs-bridge"
 description = "High level bindings to Qulacs the Quantum Circuit Simulator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 keywords = ["quantum", "simulator", "qulacs"]


### PR DESCRIPTION



## 🤖 New release

* `qulacs-bridge`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/quantinuum-dev/qulacs-bridge/compare/v0.1.0...v0.1.1) - 2025-04-11

### Other

- Pass env var
- Improve pauli conversion
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).