### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/quantinuum-dev/qulacs-bridge/compare/v0.1.4...v0.1.5) - 2025-04-15
+
+### Fixed
+
+- Use a raw loop ([#28](https://github.com/quantinuum-dev/qulacs-bridge/pull/28))
+
 ## [0.1.4](https://github.com/quantinuum-dev/qulacs-bridge/compare/v0.1.3...v0.1.4) - 2025-04-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "qulacs-bridge"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qulacs-bridge"
 description = "High level bindings to Qulacs the Quantum Circuit Simulator"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "Apache-2.0"
 keywords = ["quantum", "simulator", "qulacs"]


### PR DESCRIPTION



## 🤖 New release

* `qulacs-bridge`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/quantinuum-dev/qulacs-bridge/compare/v0.1.4...v0.1.5) - 2025-04-15

### Fixed

- Use a raw loop ([#28](https://github.com/quantinuum-dev/qulacs-bridge/pull/28))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).